### PR TITLE
cpu-kvm: Add details to failed entry panic.

### DIFF
--- a/src/cpu/kvm/base.cc
+++ b/src/cpu/kvm/base.cc
@@ -1109,8 +1109,9 @@ Tick
 BaseKvmCPU::handleKvmExitFailEntry()
 {
     dump();
-    panic("KVM: Failed to enter virtualized mode (hw reason: 0x%llx)\n",
-          _kvmRun->fail_entry.hardware_entry_failure_reason);
+    unsigned int reason = _kvmRun->fail_entry.hardware_entry_failure_reason;
+    panic("KVM: Failed to enter virtualized mode (hw reason: %s)\n",
+          vm.getHWFailReason(reason));
 }
 
 Tick

--- a/src/cpu/kvm/vm.cc
+++ b/src/cpu/kvm/vm.cc
@@ -40,6 +40,7 @@
 
 #include "cpu/kvm/vm.hh"
 
+#include <asm/vmx.h>
 #include <fcntl.h>
 #include <linux/kvm.h>
 #include <sys/ioctl.h>
@@ -49,6 +50,7 @@
 
 #include <cerrno>
 #include <memory>
+#include <string>
 
 #include "cpu/kvm/base.hh"
 #include "debug/Kvm.hh"
@@ -62,6 +64,10 @@
 #endif
 
 Kvm *Kvm::instance = NULL;
+
+//List of hardware errors
+//
+std::map<int, std::string> errStr = {VMX_EXIT_REASONS};
 
 Kvm::Kvm()
     : kvmFD(-1), apiVersion(-1), vcpuMMapSize(0)
@@ -314,6 +320,12 @@ KvmVM::~KvmVM()
 
     if (kvm)
         delete kvm;
+}
+
+std::string
+KvmVM::getHWFailReason(unsigned int  error)
+{
+    return errStr[error & ~(VMX_EXIT_REASONS_FAILED_VMENTRY)];
 }
 
 void

--- a/src/cpu/kvm/vm.hh
+++ b/src/cpu/kvm/vm.hh
@@ -41,6 +41,7 @@
 #ifndef __CPU_KVM_KVMVM_HH__
 #define __CPU_KVM_KVMVM_HH__
 
+#include <string>
 #include <vector>
 
 #include "base/addr_range.hh"
@@ -297,6 +298,12 @@ class KvmVM : public SimObject
     virtual ~KvmVM();
 
     void notifyFork();
+
+    /*
+     * Return a string corresponding to the error associated to
+     * hardware failure.
+     */
+    std::string getHWFailReason(unsigned int  error);
 
     /**
      * Setup a shared three-page memory region used by the internals


### PR DESCRIPTION
Copied strings from the kernel that contain reasons regarding hardware failures.
Currently, KVM failures report an unsigned integer as a failure reason; these
integers are now mapped to specific hardware failure reasons.